### PR TITLE
Add Facebook and Twitter social sharing

### DIFF
--- a/blog.conf
+++ b/blog.conf
@@ -6,6 +6,7 @@ posts_dir: ./posts
 github: prabirshrestha
 twitter: prabirshrestha
 mastodon: https://mastodon.social/@prabirshrestha
+facebook: prabirshrestha
 syntax_highlight: true
 # google_analytics:
 #     ga_measurement_id: changeme

--- a/src/blog.rs
+++ b/src/blog.rs
@@ -26,6 +26,7 @@ pub struct BlogConf {
     github: Option<String>,
     mastodon: Option<String>,
     twitter: Option<String>,
+    facebook: Option<String>,
     disqus: Option<String>,
     giscus: Option<Giscus>,
     google_analytics: Option<GoogleAnalytics>,
@@ -184,6 +185,10 @@ impl BlogConf {
 
     pub fn get_twitter(&self) -> Option<&str> {
         self.twitter.as_deref()
+    }
+
+    pub fn get_facebook(&self) -> Option<&str> {
+        self.facebook.as_deref()
     }
 
     pub fn get_disqus(&self) -> Option<&str> {

--- a/templates/base.rs.html
+++ b/templates/base.rs.html
@@ -28,6 +28,9 @@
                 @if let Some(twitter) = blog.get_blog_conf().get_twitter() {
                     <a href="https://twitter.com/@twitter">Twitter</a>
                 }
+                @if let Some(facebook) = blog.get_blog_conf().get_facebook() {
+                    <a href="https://facebook.com/@facebook">Facebook</a>
+                }
             </nav>
         </header>
         <main>
@@ -43,6 +46,9 @@
             }
             @if let Some(twitter) = blog.get_blog_conf().get_twitter() {
                 <a href="https://twitter.com/@twitter">Twitter</a>
+            }
+            @if let Some(facebook) = blog.get_blog_conf().get_facebook() {
+                <a href="https://facebook.com/@facebook">Facebook</a>
             }
             <a href="/rss">
                 <a href="/rss">RSS</a>


### PR DESCRIPTION
Add Facebook social sharing functionality.

* **blog.conf**
  - Add `facebook` field to the configuration.

* **src/blog.rs**
  - Add `facebook` field to the `BlogConf` struct.
  - Update the `BlogConf` implementation to handle the new `facebook` field.

* **templates/base.rs.html**
  - Add a link to Facebook in the header and footer.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/prabirshrestha/rblog?shareId=71db0334-b450-497b-8e19-0ed58b62a2d8).