### PR TITLE
fix: prevent infinite reload loop from recursive watcher setup

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -247,7 +247,14 @@ async fn watch_for_changes(config_file: String, state: Arc<ArcSwap<AppState>>, i
             tokio::select! {
                 event = rx.recv() => {
                     match event {
-                        Some(Ok(_)) => {}
+                        Some(Ok(e)) => {
+                            // Skip pure Access events — inotify generates these when the
+                            // recursive watcher setup traverses directories via readdir,
+                            // which would cause a reload loop if not filtered.
+                            if matches!(e.kind, notify::EventKind::Access(_)) {
+                                continue;
+                            }
+                        }
                         Some(Err(e)) => {
                             warn!("Watch error: {}", e);
                             continue 'outer;
@@ -291,9 +298,14 @@ async fn watch_for_changes(config_file: String, state: Arc<ArcSwap<AppState>>, i
             info!("Change detected, reloading blog...");
             do_reload(&config_file, &state).await;
 
-            // Re-establish watcher — posts_dir canonical path may have changed after a
-            // git-sync symlink swap, so we always restart fresh after each reload
-            continue 'outer;
+            // Re-establish the watcher only if the canonical path changed (git-sync
+            // symlink swap). Always restarting caused an infinite reload loop:
+            // creating a recursive inotify watcher traverses directories via readdir,
+            // which generates Access events that were caught as "changes".
+            if posts_dir.canonicalize().ok() != canonical_at_setup {
+                continue 'outer;
+            }
+            // Canonical path unchanged — keep the existing watcher running.
         }
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -128,16 +128,15 @@ fn symlink_parents(path: &Path) -> (Vec<PathBuf>, bool) {
         if std::fs::symlink_metadata(&current)
             .map(|m| m.is_symlink())
             .unwrap_or(false)
+            && let Some(parent) = current.parent()
         {
-            if let Some(parent) = current.parent() {
-                let parent = parent.to_path_buf();
-                // parent.parent().is_none() is true for filesystem roots on all
-                // platforms: `/` on Unix, `C:\` / `\\server\share` on Windows.
-                if parent.parent().is_none() {
-                    needs_fallback = true;
-                } else if !parents.contains(&parent) {
-                    parents.push(parent);
-                }
+            let parent = parent.to_path_buf();
+            // parent.parent().is_none() is true for filesystem roots on all
+            // platforms: `/` on Unix, `C:\` / `\\server\share` on Windows.
+            if parent.parent().is_none() {
+                needs_fallback = true;
+            } else if !parents.contains(&parent) {
+                parents.push(parent);
             }
         }
         if !current.pop() {


### PR DESCRIPTION
## Problem

After v0.300.0, rblog reloads continuously every ~1 second in an infinite loop:

```
Watching "/data/current/posts" and "/data/current/blog.yaml" for changes
Change detected, reloading blog...
Blog reloaded successfully
Watching "/data/current/posts" and "/data/current/blog.yaml" for changes
Change detected, reloading blog...   ← 1 second later, forever
```

## Root Cause

Two issues compound to create the loop:

1. **`continue 'outer` after every reload**: `watch_for_changes` unconditionally re-created the watcher after each reload.

2. **Recursive inotify watcher setup generates Access events**: When `notify` sets up a `RecursiveMode::Recursive` watch, it traverses the directory tree via `readdir` to enumerate subdirectories. `readdir` generates inotify `IN_ACCESS` events on those directories. Since the watcher is already listening, these self-generated events were caught as "changes", triggering a reload → watcher re-created → more Access events → loop forever.

## Fix

1. **Filter Access events** — readdir-generated access notifications should never trigger a blog reload. Only Create/Modify/Remove/Rename events matter.

2. **Only re-establish watcher when canonical path changes** — the watcher only needs to be re-created when git-sync performs a symlink swap (canonical path changes). For normal file edits, the existing watcher stays alive. This also avoids the extra setup-event reload after each symlink swap.